### PR TITLE
Remove CLI configuration from segmentation script

### DIFF
--- a/ex_segmentation/README.md
+++ b/ex_segmentation/README.md
@@ -14,9 +14,10 @@ Schwellwertbildung, Morphologie und Export aus.
    eingelesen.
 2. **Pipeline konfigurieren** – Parameter werden über die
    [`PipelineParameters`](./batch_segment_multiple_images.py)
-   Struktur festgelegt. Dies geschieht entweder im Skript selbst (`USE_MANUAL_CONFIGURATION`)
-   oder über CLI-Argumente, die von
-   [`parse_args`](./batch_segment_multiple_images.py) verarbeitet werden.
+   Struktur festgelegt. Dies geschieht direkt im Skript (z. B. via
+   [`MANUAL_CONFIGURATION`](./batch_segment_multiple_images.py)) oder über
+   externe Konfigurationsdateien, die eine
+   [`ManualConfiguration`](./batch_segment_multiple_images.py) befüllen.
 3. **Segmentierung ausführen** –
    [`process_images`](./batch_segment_multiple_images.py) bzw.
    [`segment_image`](./batch_segment_multiple_images.py)
@@ -30,7 +31,7 @@ Schwellwertbildung, Morphologie und Export aus.
 
 | Skript | Zweck | Wichtige Funktionen |
 | --- | --- | --- |
-| `batch_segment_multiple_images.py` | Stapelverarbeitung kompletter Ordner mit identischen Pipelineparametern. | [`PipelineParameters`](./batch_segment_multiple_images.py), [`build_pipeline`](./batch_segment_multiple_images.py), [`process_images`](./batch_segment_multiple_images.py) |
+| `batch_segment_multiple_images.py` | Stapelverarbeitung kompletter Ordner mit identischen Pipelineparametern. | [`PipelineParameters`](./batch_segment_multiple_images.py), [`build_manual_configuration`](./batch_segment_multiple_images.py), [`process_images`](./batch_segment_multiple_images.py) |
 | `batch_segment_single_image.py` | Vorlage für reproduzierbare Einzelbild-Segmentierung mit festen Hyperparametern. | [`sdrv.apply_driver_denoise`](../imppy3d_functions/ski_driver_functions.py), [`sdrv.apply_driver_thresholding`](../imppy3d_functions/ski_driver_functions.py), [`sdrv.apply_driver_morph`](../imppy3d_functions/ski_driver_functions.py) |
 | `interactive_processing_single_image.py` | Interaktiver Jupyter-/Matplotlib-Workflow zur Schritt-für-Schritt-Anpassung. | [`interact_adaptive_thresholding`](./interactive_processing_single_image.py), [`interact_del_features`](./interactive_processing_single_image.py), [`interact_skeletonize`](./interactive_processing_single_image.py) |
 
@@ -75,8 +76,10 @@ Skripten dokumentiert und künftig über Docstrings gepflegt.
 
 ## Sonderfälle und weiterführende Docstrings
 
-* **Invertierte Kontraste** – Wenn Korngrenzen dunkel erscheinen, kann die
-  CLI-Option `invert_grayscale` gesetzt werden. Die Auswirkungen auf die
+* **Invertierte Kontraste** – Wenn Korngrenzen dunkel erscheinen, kann in der
+  [`ManualConfiguration`](./batch_segment_multiple_images.py) bzw. in den
+  [`PipelineParameters`](./batch_segment_multiple_images.py) das Feld
+  `invert_grayscale` gesetzt werden. Die Auswirkungen auf die
   Schwellenwertlogik beschreibt der Docstring von
   [`apply_driver_thresh`](../imppy3d_functions/cv_driver_functions.py).
 * **Batch-Optimierung** – In Stapelläufen sollten die OpenCV-Treiber mit

--- a/imppy3d_functions/README.md
+++ b/imppy3d_functions/README.md
@@ -44,7 +44,8 @@ Funktionen für den einfachen Import in den Beispielskripten.
   [`apply_driver_denoise`](./ski_driver_functions.py#L389),
   [`apply_driver_sharpen`](./ski_driver_functions.py#L242) und
   [`apply_driver_thresholding`](./ski_driver_functions.py#L87) auf, um komplexe
-  `scikit-image`-Aufrufe zu kapseln und für CLI-/Batch-Jobs zugänglich zu machen.
+  `scikit-image`-Aufrufe zu kapseln und für automatisierte Batch-Jobs zugänglich
+  zu machen.
 * Die Intersections-Pipeline nutzt
   [`grain_size_functions.find_intersections`](./grain_size_functions.py#L6) zur
   Ermittlung der Schnittpunkte sowie
@@ -63,9 +64,11 @@ häufigsten Stolperfallen bündelt:
 
 * **Invertierte Grauwerte / Binärmasken** – Für Segmentierungen, deren
   Grenzen dunkel statt hell sind, kann `apply_driver_thresh` direkt auf
-  invertierte Eingaben angewendet werden. Alternativ bietet die
-  Segmentierungs-CLI das Flag `invert_grayscale` (siehe
-  [`batch_segment_multiple_images.py`](../ex_segmentation/batch_segment_multiple_images.py)).
+  invertierte Eingaben angewendet werden. Alternativ lässt sich in den
+  Segmentierungskonfigurationen (`ManualConfiguration` bzw.
+  `PipelineParameters`, siehe
+  [`batch_segment_multiple_images.py`](../ex_segmentation/batch_segment_multiple_images.py))
+  das Feld `invert_grayscale` setzen.
 * **Batch-Ausführung** – Alle `apply_*`-Funktionen akzeptieren `quiet_in=True`,
   um Protokollausgaben in Stapelläufen zu vermeiden. Dies gilt insbesondere für
   `apply_driver_denoise`, das durch große Suchfenster deutlich längere Laufzeiten


### PR DESCRIPTION
## Summary
- remove the argparse-based CLI from `batch_segment_multiple_images.py` and drive execution purely via Python dataclasses
- introduce `ExecutionParameters` plus a streamlined `main` that consumes `ManualConfiguration` or direct pipeline overrides
- update segmentation and helper READMEs to document the script/TOML-centric workflow

## Testing
- python -m compileall ex_segmentation/batch_segment_multiple_images.py

------
https://chatgpt.com/codex/tasks/task_e_68cd868490b0832fbbfe00ddea19bea3